### PR TITLE
Reduce whitespace characters to a single space matching with predefined character class

### DIFF
--- a/src/ngrams/Tokenizer.java
+++ b/src/ngrams/Tokenizer.java
@@ -38,11 +38,9 @@ public class Tokenizer {
 
     public void startTokenization() throws IOException {
         europarlString = new String(Files.readAllBytes(fileToBeRead.toPath()));
-        String replace = europarlString.replace("\n", " ");
-        String replace1 = replace.replace("\r", " ");
-        String replace2 = replace1.replace("\n\r", " ");
-        String replace3 = replace2.replace("-", " ");
-        String[] split = replace3.split(" ");
+        String replace = europarlString.replace("\\s+", " ");
+        String replace2 = replace.replace("-", " ");
+        String[] split = replace2.split(" ");
         boolean isNewSentence = true;
         for (int i = numberOfNgrams - 1; i < split.length; i++) {
             String token = new String();


### PR DESCRIPTION
This is done to handle a case like this

``` Java
"token1 token2  token3                token4\ftoken5"
```

See http://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html
